### PR TITLE
Update get_vtab1k.py

### DIFF
--- a/data/vtab-source/get_vtab1k.py
+++ b/data/vtab-source/get_vtab1k.py
@@ -68,7 +68,7 @@ for dataset_name, dataset_params in dataset_config:
         
         with open(f'{data_root}/{dataset_name}/{split_name}.txt', 'w') as f:
             for i, item in enumerate(data):
-                image_path = f'images/{split_name}/{i:06d}.jpg'
+                image_path = f'images/{split_name}/{i:06d}.png'
                 label = item['label'].numpy().item()
                 f.write(f'{image_path} {label}\n')
                 


### PR DESCRIPTION
This pull request changes JPEG to lossless PNG when creating VTAB-1k dataset. 

For some datasets such as CIFAR100, converting original images to JPEG format with default quality level may affect the test performance of some models (such as CLIP/SigLIP). 

Related to #28.